### PR TITLE
Updated location query, now grouped

### DIFF
--- a/src/static/js/modules/query.js
+++ b/src/static/js/modules/query.js
@@ -307,7 +307,6 @@ var PDP = (function ( pdp ) {
         var consolidatedName, groupName;
         // If the parameter is an enumerated (state-code-1) field then
         if ( paramName.match(/\-\d+$/) ) {
-          param.joiner = ' OR ';
           
           // If this is a special case with county, state, or census tract
           // then they needs to be grouped together as an object for appropriate query creation


### PR DESCRIPTION
- Split out location filters to separate Location Object to allow for grouping, proper query order
- Added configurable joiner (And / Or) Instead of RegExp conversion
- State, County, and Census Tract are now grouped by enumerated property ((state-code-1 AND county-code-1 AND census-tract-1) OR (state-code-2 AND county-code-2))
