### PR TITLE
Remove double quotes to make jshint happy

### DIFF
--- a/src/static/js/modules/query.js
+++ b/src/static/js/modules/query.js
@@ -378,7 +378,7 @@ var PDP = (function ( pdp ) {
       // For each location group, iterate through and create valid, grouped query string
       _.forEach( locGroup, function(i, val){
         var queryStr = '', item = locGroup[val];
-        if( item.stateValue === "" ){
+        if( item.stateValue === '' ){
         } else if( item.countyValues.length === 0 ){
           queryStr += 'state_code=' + item.stateValue;
           locVals.push(queryStr);


### PR DESCRIPTION
Whoops some double quotes snuck in and are causing jshint to fail.

BTW, the app follows the [idiomatic.js style guide](https://github.com/rwaldron/idiomatic.js/) if you're wondering why there's often whitespace around arguments.
