### PR TITLE
Add better handling for options and errors

### DIFF
--- a/src/content/homepage/charts/second-chart/convert-msaxlsx-to-html.sh
+++ b/src/content/homepage/charts/second-chart/convert-msaxlsx-to-html.sh
@@ -1,23 +1,68 @@
 #! /bin/bash
+#
+# Background:
+# This script can be used to import an XLSX file that contains MSA codes and
+# names. These fields will be pulled out and placed into an html formatted file
+# that can be used by hmda-explorer.
 
 HTMLDROPDOWN_FILE="msa-dropdown.html"
+TMPCSV="tmp-msa.csv"
+CODE_COLUMN=1
+TEXT_COLUMN=2
+
+OPTIONS_GUIDE="Usage: convert-msalsx-to-html.sh [-c code-column] [-t text-column] [-o output-file] input-file
+    -c	Default: $CODE_COLUMN
+    -t	Default: $TEXT_COLUMN
+    -o	Default: $HTMLDROPDOWN_FILE
+"
+
+# Pull out the command line arguments (if any)
+while getopts ":c:t:o:h" opt; do
+    case $opt in
+        c)
+            CODE_COLUMN=$OPTARG
+            ;;
+        t)
+            TEXT_COLUMN=$OPTARG
+            ;;
+        o)
+            HTMLDROPDOWN_FILE=$OPTARG
+            ;;
+        h)
+            echo "$OPTIONS_GUIDE" >&2
+            exit 0
+            ;;
+        \?)
+            echo "Invalid option: -$OPTARG" >&2
+            echo "$OPTIONS_GUIDE" >&2
+            exit 1
+            ;;
+    esac
+done
+
+shift $((OPTIND-1))  #This tells getopts to move on to the next argument.
+
 if [ $# -ne 1 ]; then
-     echo "usage: $0 <xlsx-filename>"
+     echo "Please include the input file"
+     echo "$OPTIONS_GUIDE" >&2
      exit 1
 fi
 
-# https://github.com/dilshod/xlsx2csv (this gracefully handles unicode nastiness, thankfully).
-TMPCSV="tmp-msa.csv"
-xlsx2csv -d '|' $1 $TMPCSV 2> /dev/null || {
+# Use xlsx2csv to convert the xlsx file: https://github.com/dilshod/xlsx2csv
+# If xlsx2csv is not installed, exit
+command -v xlsx2csv 2> /dev/null || {
     echo >&2 "'xlsx2csv' is required for this script to execute. To install, run:
 pip install xlsx2csv 
 Note that root access may be required to run pip commands. Aborting.";
     exit 1;
 } 
 
+# This gracefully handles unicode nastiness, thankfully.
+xlsx2csv -d '|' "$1" $TMPCSV
+
 echo '<select name="hmda_chart_2_msa" id="hmda_chart_2_msa">
 <option selected value="CBSA00000">U.S. Total</option>' > $HTMLDROPDOWN_FILE
-awk -F "|" '{ if(NR>1){print("<option value=\"CBSA"$1"\">"$2"</option>")}}' $TMPCSV >> $HTMLDROPDOWN_FILE
+awk -F "|" '{ if(NR>1){print("<option value=\"CBSA"$'$CODE_COLUMN'"\">"$'$TEXT_COLUMN'"</option>")}}' $TMPCSV >> $HTMLDROPDOWN_FILE
 echo '</select>' >> $HTMLDROPDOWN_FILE
 
 echo 'successfully created: '$HTMLDROPDOWN_FILE


### PR DESCRIPTION
- Improve test for existance xlsx2csv. The old way would print a message if the command failed for any reason.  Now it tests explicitly for its existance before printing the pip install message.
- parameterize output file and csv column parsing of MSA code and name
- Add a `-h` help option