### PR TITLE
Add link to Consumer Complaint Database + description

### DIFF
--- a/src/learn-more.html
+++ b/src/learn-more.html
@@ -206,7 +206,19 @@
         </div>
       </div>
     </section>  
-      
+
+
+    <section id="other-resources">
+      <div class="background">
+        <div class="inner">
+          <h2>Other CFPB Data</h2>
+          <p>The CFPB also <a href="http://www.consumerfinance.gov/complaintdatabase/">publishes complaint information</a> on mortgages as well as other financial products. The data show the kinds of issues consumers have reported and how different companies have responded. You can view, sort and analyze the data, or you can download or build on the data using our API.</p>
+
+
+
+        </div>
+      </div>
+    </section> 
 
             
 </div>


### PR DESCRIPTION
Adds a section that describes the Consumer Complaint Database and links to the CCDB landing page.

Part of CCDB 4.1 project release see [ghe for deets](GHE/CCDB4/ccdb-4.1-planning/issues/102). This can be merged + deployed before or on 1/28

## Additions

- Some copy on the About page

## Testing

- check this branch out locally + follow setup steps to see the new copy at 

## Review

- @contolini 
- @sonnakim

## Screenshots
![screen shot 2016-01-20 at 3 47 09 pm](https://cloud.githubusercontent.com/assets/702526/12462717/d0805dc2-bf8d-11e5-9ded-6a88fb09228a.png)
![screen shot 2016-01-20 at 3 46 19 pm](https://cloud.githubusercontent.com/assets/702526/12462728/db7761bc-bf8d-11e5-9844-bb5a8074c232.png)

