### PR TITLE
Recursively check form field dependencies

### DIFF
--- a/src/static/js/modules/form.js
+++ b/src/static/js/modules/form.js
@@ -575,6 +575,9 @@ var PDP = (function ( pdp ) {
             emit( 'shown', $dependent, dependencies );
           });
         } else {
+          setTimeout(function(){
+            form.checkDeps([$el.attr('id')]);
+          }, 100);
           _.forEach( $dependents, function( $dependent ){
             emit( 'hidden', $dependent, $el.attr('id') );
           });


### PR DESCRIPTION
JIRA #DPT-103 is happening because the app looks for [form fields that have dependents](https://github.com/contolini/hmda-explorer/blob/111d6c36a365ec2c3e6bba1bbcc264cceb1c13dd/src/static/js/modules/app.js#L81-L84) and [if those fields have a value pre-populated](https://github.com/contolini/hmda-explorer/blob/111d6c36a365ec2c3e6bba1bbcc264cceb1c13dd/src/static/js/modules/form.js#L561), their [dependents get shown](https://github.com/contolini/hmda-explorer/blob/111d6c36a365ec2c3e6bba1bbcc264cceb1c13dd/src/static/js/modules/form.js#L575). The problem is that when both a state and a county are pre-populated on page load, the county check fails (and its census dependents are not shown) because county is a dependent of state and is still hidden until a split second later.

Sooooo the hack is to re-check parent form fields that don't have values until they have values.

Before: http://www.consumerfinance.gov/data-research/hmda/explore#!/as_of_year=2014&state_code-1=42&county_code-1=043&census_tract_number-1=0201.00,0203.00,0204.00,0205.00,0206.00,0207.00,0208.00,0209.00,0211.00,0212.00,0213.00,0214.00,0215.00,0216.00,0217.00&property_type=1,2&owner_occupancy=1&loan_purpose=1&section=filters

After: https://contolini.github.io/hmda-explorer/explore.html#!/as_of_year=2014&state_code-1=42&county_code-1=043&census_tract_number-1=0201.00,0203.00,0204.00,0205.00,0206.00,0207.00,0208.00,0209.00,0211.00,0212.00,0213.00,0214.00,0215.00,0216.00,0217.00&property_type=1,2&owner_occupancy=1&loan_purpose=1&section=filters

@sephcoster @JeffreyMFarley @jessicarussell