### PR TITLE
Update Google Tag Manager snippets

### DIFF
--- a/src/api.html
+++ b/src/api.html
@@ -16,6 +16,15 @@
       <link rel="stylesheet" href="static/css/ie8.min.css">
       <script src="static/js/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-KMMLRS');</script>
+    <!-- End Google Tag Manager -->
+
     <script>
       var docElement = document.documentElement;
       docElement.className = docElement.className.replace(/(^|\s)no-js(\s|$)/, '$1$2');
@@ -27,25 +36,20 @@
   <!--[if IE 9]>         <body class="lt-ie10 hmda explore api-docs"> <![endif]-->
   <!--[if gt IE 9]><!--><body class="hmda explore api-docs"><!--<![endif]-->
 
-    <!-- Google Tag Manager -->
-  <noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-KMMLRS"
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KMMLRS"
   height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-  '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-  })(window,document,'script','dataLayer','GTM-KMMLRS');</script>
-  <!-- End Google Tag Manager -->
+  <!-- End Google Tag Manager (noscript) -->
 
-  <div id="wrap">  
+  <div id="wrap">
     <div class="top-banner">
       <div class = "inner">
         <p class="return-cfgov">Return to <a href="http://www.consumerfinance.gov">consumerfinance.gov</a></p>
         <p class="official-website">An official website of the United States Government<img src="static/img/icon_usflag.png" width="16" height="11" alt="US Flag" /></p>
       </div>
-    </div> 
+    </div>
 
-    <header role="banner"> 
+    <header role="banner">
 
       <div class="logo">
 
@@ -81,16 +85,16 @@
 
 
       <!-- api section -->
-      <div id="main"> 
+      <div id="main">
         <div id="api-docs">
-        
 
 
-        <section id="api-documentation"> 
-          
+
+        <section id="api-documentation">
+
           <div class="background">
             <div class="inner">
-          
+
             <%= api_api_body %>
 
               <div class="links">
@@ -111,7 +115,7 @@
         </section>
 
 
-        
+
 
         </div>
 

--- a/src/des-update-2017.html
+++ b/src/des-update-2017.html
@@ -16,6 +16,15 @@
       <link rel="stylesheet" href="static/css/ie8.min.css">
       <script src="static/js/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-KMMLRS');</script>
+    <!-- End Google Tag Manager -->
+
     <script>
       var docElement = document.documentElement;
       docElement.className = docElement.className.replace(/(^|\s)no-js(\s|$)/, '$1$2');
@@ -27,15 +36,10 @@
   <!--[if IE 9]>         <body class="lt-ie10 hmda explore learn-more"> <![endif]-->
   <!--[if gt IE 9]><!--><body class="hmda explore for-filers"><!--<![endif]-->
 
-  <!-- Google Tag Manager -->
-  <noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-KMMLRS"
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KMMLRS"
   height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-  '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-  })(window,document,'script','dataLayer','GTM-KMMLRS');</script>
-  <!-- End Google Tag Manager -->
+  <!-- End Google Tag Manager (noscript) -->
 
     <div class="top-banner">
       <div class="inner">

--- a/src/explore.html
+++ b/src/explore.html
@@ -16,6 +16,15 @@
     <link rel="stylesheet" href="static/css/ie8.min.css">
     <script src="static/js/respond.min.js"></script>
   <![endif]-->
+
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-KMMLRS');</script>
+  <!-- End Google Tag Manager -->
+
   <script>
     var docElement = document.documentElement;
     docElement.className = docElement.className.replace(/(^|\s)no-js(\s|$)/, '$1$2');
@@ -26,23 +35,18 @@
 <!--[if IE 8]>         <body class="lt-ie9 hmda explore"> <![endif]-->
 <!--[if IE 9]>         <body class="lt-ie10 hmda explore"> <![endif]-->
 <!--[if gt IE 9]><!--><body class="hmda explore"><!--<![endif]-->
-  
-  <!-- Google Tag Manager -->
-  <noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-KMMLRS"
-  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-  '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-  })(window,document,'script','dataLayer','GTM-KMMLRS');</script>
-  <!-- End Google Tag Manager -->
+
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KMMLRS"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
 
   <div class="top-banner">
     <div class="inner">
       <p class="return-cfgov">Return to <a href="http://www.consumerfinance.gov">consumerfinance.gov</a></p>
       <p class="official-website">An official website of the United States Government<img src="static/img/icon_usflag.png" width="16" height="11" alt="US Flag" /></p>
     </div>
-  </div> 
+  </div>
 
   <header role="banner">
 
@@ -139,7 +143,7 @@
                 <span class="cf-icon cf-icon-error-round highlight"></span>
                 <p class="message">Additional Data</p>
                 <p class="action"><%= missing_2014_warning %></p>
-              </div>              
+              </div>
             </li>
             <!-- /filter field -->
 
@@ -167,7 +171,7 @@
             <%= explore_intro_text %>
 
           </div>
-          
+
         </div>
 
         <!-- /filter section -->
@@ -176,7 +180,7 @@
 
         <div class="filter location closed" id="location">
 
-          <div class="title"> 
+          <div class="title">
 
             <a href="#location"><h3><i class="cf-icon cf-icon-minus-round"></i> Location</h3></a>
 
@@ -187,7 +191,7 @@
           <div id="location-sets"></div>
 
           <a href="#" id="add-state" class="control">+ Add another state or metro area</a>
-          
+
         </div>
 
         <!-- /filter section -->
@@ -205,7 +209,7 @@
           </div>
 
           <ul class="fields">
-            
+
             <!-- filter field -->
             <li class="field popular">
               <label for="property_type">Property Type:</label>
@@ -233,7 +237,7 @@
             <!-- /filter field -->
 
           </ul>
-          
+
         </div>
 
         <!-- /filter section -->
@@ -306,7 +310,7 @@
               </div>
               <div class="help" role="tooltip"><i class="cf-icon cf-icon-help-round"></i></div>
               <span class="help-text"><%= explore_tooltips_lien_status %></span>
-              
+
             </li>
             <!-- /filter field -->
 
@@ -320,7 +324,7 @@
               <div class="help" role="tooltip"><i class="cf-icon cf-icon-help-round"></i></div>
               <span class="help-text"><%= explore_tooltips_rate_spread %></span>
             </li>
-            <!-- /filter field -->            
+            <!-- /filter field -->
 
             <!-- filter field -->
             <li class="field optional-toggle" data-optional="loan_optional">
@@ -341,7 +345,7 @@
                 <span>$</span><input type="text" class="param require-numeric min-value" name="loan_amount_000s-min" data-comparator=">=" value="" placeholder="Min."><span class="thousands">,000 &nbsp; to &nbsp;</span>
                 <span>$</span><input type="text" class="param require-numeric max-value" name="loan_amount_000s-max" data-comparator="<=" value="" placeholder="Max."><span class="thousands">,000</span>
               </div>
-              
+
             </li>
             <!-- /filter field -->
 
@@ -413,7 +417,7 @@
             <!-- /filter field -->
 
           </ul>
-          
+
         </div>
 
         <!-- /filter section -->
@@ -465,7 +469,7 @@
 
 
           </ul>
-          
+
         </div>
 
         <!-- /filter section -->
@@ -610,7 +614,7 @@
             <!-- /filter field -->
 
           </ul>
-          
+
         </div>
 
         <!-- /filter section -->
@@ -659,7 +663,7 @@
           <div id="preview">
             <div class="spinning"></div>
           </div>
-        
+
       </div>
 
       <!-- /preview section -->
@@ -687,10 +691,10 @@
             <div class="radio widget codes">
               <label><input type="radio" name="codes" value="0" checked />Include labels</label>
               <label><input type="radio" name="codes" value="1" />Include labels and codes</label>
-              
+
               <div class="help" role="tooltip"><i class="cf-icon cf-icon-help-round bump-up"></i></div>
               <span class="help-text"><%= explore_tooltips_download_raw_data %></span>
-              
+
             </div>
 
             <div class="msg mobile-warning">
@@ -769,10 +773,10 @@
     </div>
 
     <form id="summary-table-form">
-      
+
       <div class="drop-downs">
         <div class="variable">
-          
+
           <select id="variable0" class="chzn-single" data-summary-table-input="both" data-placeholder="Select the first variable">
             <option value></option>
           </select>
@@ -821,7 +825,7 @@
           </div>
         </div>
       </div>
-      
+
 
       <div class="spinning"></div>
 
@@ -934,7 +938,7 @@
       </div>
 
       <!-- download and share section -->
-        
+
     </form>
 
   </div>

--- a/src/faq.html
+++ b/src/faq.html
@@ -16,18 +16,15 @@
       <link rel="stylesheet" href="static/css/ie8.min.css">
       <script src="static/js/respond.min.js"></script>
     <![endif]-->
-    <script>
-      var _gaq = _gaq || [];
-      _gaq.push(['_setAccount', 'UA-20466645-3']);
-      _gaq.push(['_setDomainName', '.consumerfinance.gov']);
-      _gaq.push(['_trackPageview']);
 
-      (function() {
-        var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-        ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-        var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-      })();
-    </script>
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-KMMLRS');</script>
+    <!-- End Google Tag Manager -->
+
     <script>
       var docElement = document.documentElement;
       docElement.className = docElement.className.replace(/(^|\s)no-js(\s|$)/, '$1$2');
@@ -39,15 +36,10 @@
   <!--[if IE 9]>         <body class="lt-ie10 hmda explore learn-more"> <![endif]-->
   <!--[if gt IE 9]><!--><body class="hmda explore for-filers"><!--<![endif]-->
 
-  <!-- Google Tag Manager -->
-  <noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-KMMLRS"
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KMMLRS"
   height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-  '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-  })(window,document,'script','dataLayer','GTM-KMMLRS');</script>
-  <!-- End Google Tag Manager -->
+  <!-- End Google Tag Manager (noscript) -->
 
     <div class="top-banner">
       <div class="inner">

--- a/src/for-filers.html
+++ b/src/for-filers.html
@@ -16,6 +16,15 @@
       <link rel="stylesheet" href="static/css/ie8.min.css">
       <script src="static/js/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-KMMLRS');</script>
+    <!-- End Google Tag Manager -->
+
     <script>
       var docElement = document.documentElement;
       docElement.className = docElement.className.replace(/(^|\s)no-js(\s|$)/, '$1$2');
@@ -27,15 +36,10 @@
   <!--[if IE 9]>         <body class="lt-ie10 hmda explore learn-more"> <![endif]-->
   <!--[if gt IE 9]><!--><body class="hmda explore for-filers"><!--<![endif]-->
 
-  <!-- Google Tag Manager -->
-  <noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-KMMLRS"
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KMMLRS"
   height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-  '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-  })(window,document,'script','dataLayer','GTM-KMMLRS');</script>
-  <!-- End Google Tag Manager -->
+  <!-- End Google Tag Manager (noscript) -->
 
     <div class="top-banner">
       <div class="inner">

--- a/src/index.html
+++ b/src/index.html
@@ -18,21 +18,15 @@
     <link rel="stylesheet" href="static/css/ie8.min.css">
     <script src="static/js/respond.min.js"></script>
   <![endif]-->
-  <script>
-  var _gaq = _gaq || [];
-  _gaq.push(['_setAccount', 'UA-20466645-3']);
-  _gaq.push(['_setDomainName', '.consumerfinance.gov']); // For production
-  _gaq.push(['_trackPageview']);
 
-  (function() {
-    var ga = document.createElement('script');
-    ga.type = 'text/javascript';
-    ga.async = true;
-    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-    var s = document.getElementsByTagName('script')[0];
-    s.parentNode.insertBefore(ga, s);
-  })();
-  </script>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-KMMLRS');</script>
+  <!-- End Google Tag Manager -->
+
   <script>
   var docElement = document.documentElement;
   docElement.className = docElement.className.replace(/(^|\s)no-js(\s|$)/, '$1$2');
@@ -44,16 +38,11 @@
 <!--[if IE 8]>         <body class="lt-ie9 hmda homepage"> <![endif]-->
 <!--[if IE 9]>         <body class="lt-ie10 hmda homepage"> <![endif]-->
 <!--[if gt IE 9]><!--><body class="hmda homepage"><!--<![endif]-->
-  
-  <!-- Google Tag Manager -->
-  <noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-KMMLRS"
+
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KMMLRS"
   height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-  '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-  })(window,document,'script','dataLayer','GTM-KMMLRS');</script>
-  <!-- End Google Tag Manager -->
+  <!-- End Google Tag Manager (noscript) -->
 
   <div class="top-banner">
     <div class="inner">
@@ -267,15 +256,15 @@
               <a href="explore#!/as_of_year=2015,2014,2013&property_type=1,2&owner_occupancy=1&action_taken=1&lien_status=1&select=as_of_year,state_name,loan_purpose_name,count&section=summary" class="action-arrow underlying" data-track-label="Number of applications and originations by loan purpose">See the underlying data<i class="cf-icon cf-icon-right"></i></a>
 
               <label for="hmda_chart_1_msa" class="chart-label">Select a U.S. State</label>
-              
+
               <br>
-              
+
               <%= homepage_charts_first_chart_msa_dropdown %>
 
 
               <!-- /.row -->
-              
-            
+
+
             </div><!-- /.chart-info -->
 
             <div class="chart-content">
@@ -319,9 +308,9 @@
             <a href="explore#!/as_of_year=2015,2014,2013&property_type=1,2&owner_occupancy=1&action_taken=1&loan_purpose=1&lien_status=1&select=as_of_year,state_name,loan_type_name,count&section=summary" class="action-arrow underlying">See the underlying data<i class="cf-icon cf-icon-right"></i></a>
 
             <label for="hmda_chart_2_msa" class="chart-label">Select a U.S. State</label>
-              
+
               <br>
-              
+
               <%= homepage_charts_second_chart_msa_dropdown %>
 
             <div class="toggle-series-heading">
@@ -360,7 +349,7 @@
             </table>
 
           </div><!-- //.chart-content -->
-        
+
         </div><!-- //.background -->
       </section>
       <!-- END CHART 2 -->

--- a/src/learn-more.html
+++ b/src/learn-more.html
@@ -16,6 +16,15 @@
       <link rel="stylesheet" href="static/css/ie8.min.css">
       <script src="static/js/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-KMMLRS');</script>
+    <!-- End Google Tag Manager -->
+
     <script>
       var docElement = document.documentElement;
       docElement.className = docElement.className.replace(/(^|\s)no-js(\s|$)/, '$1$2');
@@ -26,23 +35,18 @@
   <!--[if IE 8]>         <body class="lt-ie9 hmda explore learn-more"> <![endif]-->
   <!--[if IE 9]>         <body class="lt-ie10 hmda explore learn-more"> <![endif]-->
   <!--[if gt IE 9]><!--><body class="hmda explore learn-more"><!--<![endif]-->
-  
-  <!-- Google Tag Manager -->
-  <noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-KMMLRS"
+
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KMMLRS"
   height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-  '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-  })(window,document,'script','dataLayer','GTM-KMMLRS');</script>
-  <!-- End Google Tag Manager -->
+  <!-- End Google Tag Manager (noscript) -->
 
     <div class="top-banner">
       <div class="inner">
         <p class="return-cfgov">Return to <a href="http://www.consumerfinance.gov">consumerfinance.gov</a></p>
         <p class="official-website">An official website of the United States Government<img src="static/img/icon_usflag.png" width="16" height="11" alt="US Flag"></p>
       </div>
-    </div> 
+    </div>
 
     <header role="banner">
 
@@ -78,16 +82,16 @@
 
       </div>
 
-      
-        
-<div id="learn-more"> 
 
-  <section id="what-is-hmda"> 
-        
+
+<div id="learn-more">
+
+  <section id="what-is-hmda">
+
         <div class="background">
         <div class="inner">
 
-        <p>The <a href="http://www.gpo.gov/fdsys/pkg/USCODE-2011-title12/pdf/USCODE-2011-title12-chap29.pdf">Home Mortgage Disclosure Act (HMDA)</a> requires many financial institutions to maintain, report, and publicly disclose information about mortgages.  HMDA was originally enacted by Congress in 1975 and is implemented by <a href="http://www.gpo.gov/fdsys/pkg/CFR-2012-title12-vol8/xml/CFR-2012-title12-vol8-part1003.xml">Regulation C</a>.  The <a href="http://www.gpo.gov/fdsys/pkg/PLAW-111publ203/pdf/PLAW-111publ203.pdf#page=723">Dodd-Frank Act</a> transferred HMDA rulemaking authority from the Federal Reserve Board to the Consumer Financial Protection Bureau (CFPB) on July 21, 2011. 
+        <p>The <a href="http://www.gpo.gov/fdsys/pkg/USCODE-2011-title12/pdf/USCODE-2011-title12-chap29.pdf">Home Mortgage Disclosure Act (HMDA)</a> requires many financial institutions to maintain, report, and publicly disclose information about mortgages.  HMDA was originally enacted by Congress in 1975 and is implemented by <a href="http://www.gpo.gov/fdsys/pkg/CFR-2012-title12-vol8/xml/CFR-2012-title12-vol8-part1003.xml">Regulation C</a>.  The <a href="http://www.gpo.gov/fdsys/pkg/PLAW-111publ203/pdf/PLAW-111publ203.pdf#page=723">Dodd-Frank Act</a> transferred HMDA rulemaking authority from the Federal Reserve Board to the Consumer Financial Protection Bureau (CFPB) on July 21, 2011.
           <p></p>
           <p>The CFPB is taking steps to improve HMDA data. <a href="http://www.consumerfinance.gov/newsroom/?topic=hmda">Check out the latest HMDA announcements.</a>
           </p>
@@ -181,7 +185,7 @@
           <p><a href=".#video">Watch our introduction to HMDA</a> featuring Ren Essene, CFPB Senior Policy Analyst. You can also read the transcript below.</p>
 
           <div class="filter transcript closed" id="transcript-toggle" title="show the video transcript">
-            
+
               <a href="#transcript" class="internal-link">
                 <h3><i class="cf-icon cf-icon-minus-round"></i>  HMDA video transcript</h3>
               </a>
@@ -189,14 +193,14 @@
           </div>
 
           <div id="transcript-text">
-            
+
             <%= learn_more_transcript_text %>
 
           </div>
 
         </div>
       </div>
-    </section>  
+    </section>
 
 
     <section id="other-resources">
@@ -209,13 +213,13 @@
 
         </div>
       </div>
-    </section> 
+    </section>
 
-            
+
 </div>
 
   <%= footer %>
-  
+
   <script src="static/js/main.min.js"></script>
   <script>
   $(function(){
@@ -250,7 +254,7 @@
       });
 
     })();
-    
+
   });
   </script>
 </body>

--- a/src/static/hbs/list-of-fields.html
+++ b/src/static/hbs/list-of-fields.html
@@ -26,7 +26,15 @@
       }
     }
     </style>
-    
+
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-KMMLRS');</script>
+    <!-- End Google Tag Manager -->
+
     <script>
       var docElement = document.documentElement;
       docElement.className = docElement.className.replace(/(^|\s)no-js(\s|$)/, '$1$2');
@@ -37,23 +45,18 @@
   <!--[if IE 8]>         <body class="lt-ie9 hmda explore learn-more"> <![endif]-->
   <!--[if IE 9]>         <body class="lt-ie10 hmda explore learn-more"> <![endif]-->
   <!--[if gt IE 9]><!--><body class="hmda explore for-filers"><!--<![endif]-->
-  
-  <!-- Google Tag Manager -->
-  <noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-KMMLRS"
+
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KMMLRS"
   height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-  '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-  })(window,document,'script','dataLayer','GTM-KMMLRS');</script>
-  <!-- End Google Tag Manager -->
+  <!-- End Google Tag Manager (noscript) -->
 
     <div class="top-banner">
       <div class="inner">
         <p class="return-cfgov">Return to <a href="http://www.consumerfinance.gov">consumerfinance.gov</a></p>
         <p class="official-website">An official website of the United States Government<img src="static/img/icon_usflag.png" width="16" height="11" alt="US Flag"></p>
       </div>
-    </div> 
+    </div>
 
     <header role="banner">
 
@@ -89,11 +92,11 @@
 
       </div>
 
-      
-        
-<div id="list-of-fields"> 
+
+
+<div id="list-of-fields">
   <div class="col-4">
-    <section id="what-is-hmda"> 
+    <section id="what-is-hmda">
       <div class="background">
         <div class="inner">
           <div id="heading">

--- a/src/tech-preview.html
+++ b/src/tech-preview.html
@@ -16,6 +16,15 @@
       <link rel="stylesheet" href="static/css/ie8.min.css">
       <script src="static/js/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-KMMLRS');</script>
+    <!-- End Google Tag Manager -->
+
     <script>
       var docElement = document.documentElement;
       docElement.className = docElement.className.replace(/(^|\s)no-js(\s|$)/, '$1$2');
@@ -27,15 +36,10 @@
   <!--[if IE 9]>         <body class="lt-ie10 hmda explore learn-more"> <![endif]-->
   <!--[if gt IE 9]><!--><body class="hmda explore for-filers"><!--<![endif]-->
 
-  <!-- Google Tag Manager -->
-  <noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-KMMLRS"
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KMMLRS"
   height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-  '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-  })(window,document,'script','dataLayer','GTM-KMMLRS');</script>
-  <!-- End Google Tag Manager -->
+  <!-- End Google Tag Manager (noscript) -->
 
     <div class="top-banner">
       <div class="inner">


### PR DESCRIPTION
Our analytics team has requested we update our GTM snippets across all the cf.gov properties in order for new-fangled analytics features to work. This PR:

1. Moves the GTM snippet from the body to the head.
1. Leaves the `<noscript>` snippet in the body.
1. Removes some extraneous Google Analytics cruft that I found.
1. Removes a lot of trailing spaces that my editor didn't like.